### PR TITLE
Extend the readme to facilitate building

### DIFF
--- a/README.org
+++ b/README.org
@@ -95,13 +95,13 @@ This is the motivation that drives me to implement jq.el. With jq.el, we can rew
 To install all build dependencies on Ubuntu, use:
 
 #+begin_src sh
-apt install cmake build-essential autoconf libtool bison flex git libonig-dev libjq-dev emacs-common
+apt install cmake build-essential autoconf libtool
 #+end_src
 
 On Fedora, use:
 
 #+begin_src sh
-dnf install cmake make gcc gcc-c++ autoconf libtool bison flex git oniguruma-devel jq-devel emacs-devel
+dnf install cmake make gcc gcc-c++ autoconf libtool
 #+end_src
 
 ** Building

--- a/README.org
+++ b/README.org
@@ -90,6 +90,19 @@ This is the motivation that drives me to implement jq.el. With jq.el, we can rew
 * Getting Started
 ** Prerequisites
 - cmake :: >= 3.10.0
+- other build dependencies :: oniguruma headers, gcc, gcc-c++, libtool, autoconf, yacc & lex and git
+
+To install all build dependencies on Ubuntu, use:
+
+#+begin_src sh
+apt install cmake build-essential autoconf libtool bison flex git libonig-dev libjq-dev emacs-common
+#+end_src
+
+On Fedora, use:
+
+#+begin_src sh
+dnf install cmake make gcc gcc-c++ autoconf libtool bison flex git oniguruma-devel jq-devel emacs-devel
+#+end_src
 
 ** Building
 #+begin_src sh


### PR DESCRIPTION
Hey, thanks for `jq.el`. I thought it might be useful to tell people how to install all necessary prerequisites to build it, since it's not on MELPA yet.

I've tested the Fedora and Ubuntu instructions against fresh recent docker images of both distributions.